### PR TITLE
fix(instance): skip empty sev_type to avoid backend enum rejection

### DIFF
--- a/internal/provider/instance_resource.go
+++ b/internal/provider/instance_resource.go
@@ -276,9 +276,14 @@ func (r *instanceResource) Create(ctx context.Context, req resource.CreateReques
 			}
 		}
 
-		sevType := W1SevType(plan.Additional.SevType.ValueString())
 		additional = &InstanceAdditionalInput{}
-		additional.SevType = &sevType
+		// Only forward sev_type when the user explicitly set it. Sending an
+		// empty string trips the W1SevType enum validation backend-side and
+		// the createInstance call returns with a generic 500.
+		if !plan.Additional.SevType.IsNull() && !plan.Additional.SevType.IsUnknown() {
+			sevType := W1SevType(plan.Additional.SevType.ValueString())
+			additional.SevType = &sevType
+		}
 		additional.VTPM = plan.Additional.VTPM.ValueBoolPointer()
 		additional.Uefi = plan.Additional.Uefi.ValueBoolPointer()
 


### PR DESCRIPTION
## Bug

When a `wxone_instance` resource has an `additional` block but no `sev_type`, the provider sends an empty string through `W1SevType` to `createInstance`. The backend rejects it against its enum validator and returns a generic 500.

This blocks any module that uses `additional` for `vtpm`/`uefi`/`user_data` without also wanting SEV (which is most of them, since SEV requires specific flavor support).

## Reproducer

```hcl
resource "wxone_instance" "test" {
  project_id        = var.project_id
  name              = "..."
  flavor_id         = "..."
  image_id          = "..."
  subnet_id         = "..."
  availability_zone = "wx_dus_1"
  ssh_keys          = [...]

  additional = {
    user_data = {
      content = jsonencode({...})
    }
  }
}
```

`createInstance` returns 500 with no useful detail. The error becomes obvious only after pulling the GraphQL request body and noticing `sevType: ""`.

## Fix

Forward `sev_type` only when explicitly set (not null, not unknown). Other `additional` fields (`vtpm`, `uefi`, `sev_options`, `user_data`) are unaffected.

## Risk

- No schema change.
- Callers that already set `sev_type` are unaffected.
- Backwards-compatible: old behavior was "always send, even if empty" → backend rejects. New behavior is "send only when set" → backend accepts.